### PR TITLE
Use Z3 floating point to easily allow for variants

### DIFF
--- a/xorshift128plus-cracker.py
+++ b/xorshift128plus-cracker.py
@@ -58,7 +58,7 @@ class Cracker(object):
     
     def crack(self):
         for val in self.known:
-            nextval = z3.fpToFP(z3.RoundTowardZero(), next(self) & 0x1fffffffffffff, z3.Float64())/(2**53)
+            nextval = z3.fpToFP(z3.get_default_rounding_mode(), next(self) & 0x1fffffffffffff, z3.Float64())/(2**53)
             self.solver.add(nextval == val)
 
         if self.solver.check() != z3.sat:

--- a/xorshift128plus-cracker.py
+++ b/xorshift128plus-cracker.py
@@ -58,7 +58,9 @@ class Cracker(object):
     
     def crack(self):
         for val in self.known:
-            self.solver.add((next(self) & 0x1fffffffffffff) == int(val * 2**53))
+            nextval = z3.fpToFP(z3.RoundTowardZero(), next(self) & 0x1fffffffffffff, z3.Float64())/(2**53)
+            self.solver.add(nextval == val)
+
         if self.solver.check() != z3.sat:
             raise Exception("Not solved!")
         


### PR DESCRIPTION
This PR slightly modifies the semantics of how the Z3 model is created to actually use the floating point functions. This makes it straight forward to implment variants of this script where you don't get the raw output of the random() call.

For example, I was looking at code that returned:
```javascript
math.floor(1000+math.random()*9000)
```

and with this change I would just need to add the following between line 61 and 62:
```python
nextval = z3.fpRoundToIntegral(z3.RoundTowardZero(), 1000 + nextval * 9000)
```

In short, it does not change the default behaviour of the script but makes it much easier to adapt it to other situations.
